### PR TITLE
UK additions

### DIFF
--- a/countries/uk.js
+++ b/countries/uk.js
@@ -1,10 +1,15 @@
 'use strict';
 
 module.exports = [
+    'ac',
     'co',
+    'jcpc',
     'ltd',
     'me',
+    'mil',
+    'mod',
     'net',
     'org',
-    'plc'
+    'plc',
+    'sch',
 ];

--- a/countries/uk.js
+++ b/countries/uk.js
@@ -11,5 +11,5 @@ module.exports = [
     'net',
     'org',
     'plc',
-    'sch',
+    'sch'
 ];


### PR DESCRIPTION
These are the remaining active ones listed at https://en.wikipedia.org/wiki/.uk#Active which don't seem to be used 'directly'. e.g. I've not included `gov.uk` since it's now used to serve a site like any other `*.uk`.